### PR TITLE
Add --dir opt to ct task

### DIFF
--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Ct do
   """
 
   def run(args) do
-    {opts, args, rem_opts} = OptionParser.parse(args, strict: [log_dir: :string])
+    {opts, args, rem_opts} = OptionParser.parse(args, strict: [dir: :string, log_dir: :string])
     new_args = args ++ MixErlangTasks.Util.filter_opts(rem_opts)
 
     Mix.env :test
@@ -21,16 +21,14 @@ defmodule Mix.Tasks.Ct do
 
     # This is run independently, so that the test modules don't end up in the
     # .app file
-    ebin_dir = Path.join([Mix.Project.app_path, "test_beams"])
-    MixErlangTasks.Util.compile_files(Path.wildcard("ctest/**/*_SUITE.erl"), ebin_dir)
+    ebin_dir = Keyword.get(opts, :dir, "test")
 
     logdir = Keyword.get(opts, :log_dir, "ctest/logs")
     File.mkdir_p!(logdir)
 
     :ct.run_test [
       {:dir, String.to_char_list(ebin_dir)},
-      {:logdir, String.to_char_list(logdir)},
-      {:auto_compile, false}
+      {:logdir, String.to_char_list(logdir)}
     ]
   end
 end


### PR DESCRIPTION
CT will by default compile into the same dir as the `_SUITE.erl` files.
Can specify where the `_SUITE.erl` files live with `--dir path/to`

Tested on sanmiguel/rest_service
