### PR TITLE
return common test exit value & fix some minor warnings

### DIFF
--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -27,10 +27,11 @@ defmodule Mix.Tasks.Ct do
     logdir = Keyword.get(opts, :log_dir, "ctest/logs")
     File.mkdir_p!(logdir)
 
-    :ct.run_test [
-      {:dir, String.to_char_list(ebin_dir)},
-      {:logdir, String.to_char_list(logdir)},
+    {_ok, failed, {_userSkipped, autoSkipped}} = :ct.run_test [
+      {:dir, String.to_charlist(ebin_dir)},
+      {:logdir, String.to_charlist(logdir)},
       {:auto_compile, false}
     ]
+    :erlang.halt(if (failed+autoSkipped) == 0, do: 0, else: 1)
   end
 end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -10,8 +10,8 @@ defmodule MixErlangTasks.Util do
     File.mkdir_p!(dir)
 
     status = Enum.reduce(files, :ok, fn path, status ->
-      case :compile.file(String.to_char_list(path),
-        [{:outdir, String.to_char_list(dir)}, :report]) do
+      case :compile.file(String.to_charlist(path),
+        [{:outdir, String.to_charlist(dir)}, :report]) do
         {:ok, _} -> IO.puts "Compiled #{path}"; status
         :error -> :error
       end

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule MixErlangTasks.Mixfile do
       app: :mix_erlang_tasks,
       version: "0.1.0",
       elixir: "~> 1.0",
-      description: description,
-      package: package,
+      description: description(),
+      package: package(),
     ]
   end
 


### PR DESCRIPTION
For using `mix ct` in CI with e.g. Jenkins it is useful when an exit code is returned indicating failure or success.