### PR TITLE
Run all eunit modules

### DIFF
--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -28,8 +28,8 @@ defmodule Mix.Tasks.Ct do
     File.mkdir_p!(logdir)
 
     :ct.run_test [
-      {:dir, String.to_char_list(ebin_dir)},
-      {:logdir, String.to_char_list(logdir)},
+      {:dir, String.to_charlist(ebin_dir)},
+      {:logdir, String.to_charlist(logdir)},
       {:auto_compile, false}
     ]
   end

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -28,14 +28,12 @@ defmodule Mix.Tasks.Eunit do
     ebin_test = Path.join([Mix.Project.app_path, "test_beams"])
     MixErlangTasks.Util.compile_files(Path.wildcard("etest/**/*_tests.erl"), ebin_test)
 
-    all_beam_folders = for i <- [ebin_test | Mix.Project.load_paths] do
-      String.to_charlist(i)
-    end
+    test_beams_folder = String.to_charlist(ebin_test)
 
     options = if Keyword.get(opts, :verbose, false), do: [:verbose], else: []
     :eunit.test {:application, Mix.Project.config[:app]}, options
 
-    :eunit.test all_beam_folders, options
+    :eunit.test test_beams_folder, options
   end
 
   defp format_compile_opts(opts) do

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -28,8 +28,14 @@ defmodule Mix.Tasks.Eunit do
     ebin_test = Path.join([Mix.Project.app_path, "test_beams"])
     MixErlangTasks.Util.compile_files(Path.wildcard("etest/**/*_tests.erl"), ebin_test)
 
+    all_beam_folders = for i <- [ebin_test | Mix.Project.load_paths] do
+      String.to_charlist(i)
+    end
+
     options = if Keyword.get(opts, :verbose, false), do: [:verbose], else: []
     :eunit.test {:application, Mix.Project.config[:app]}, options
+
+    :eunit.test all_beam_folders, options
   end
 
   defp format_compile_opts(opts) do

--- a/lib/mix/tasks/eunit.ex
+++ b/lib/mix/tasks/eunit.ex
@@ -29,10 +29,7 @@ defmodule Mix.Tasks.Eunit do
     MixErlangTasks.Util.compile_files(Path.wildcard("etest/**/*_tests.erl"), ebin_test)
 
     test_beams_folder = String.to_charlist(ebin_test)
-
     options = if Keyword.get(opts, :verbose, false), do: [:verbose], else: []
-    :eunit.test {:application, Mix.Project.config[:app]}, options
-
     :eunit.test test_beams_folder, options
   end
 

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -10,8 +10,8 @@ defmodule MixErlangTasks.Util do
     File.mkdir_p!(dir)
 
     status = Enum.reduce(files, :ok, fn path, status ->
-      case :compile.file(String.to_char_list(path),
-        [{:outdir, String.to_char_list(dir)}, :report]) do
+      case :compile.file(String.to_charlist(path),
+        [{:outdir, String.to_charlist(dir)}, :report]) do
         {:ok, _} -> IO.puts "Compiled #{path}"; status
         :error -> :error
       end

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule MixErlangTasks.Mixfile do
       app: :mix_erlang_tasks,
       version: "0.1.0",
       elixir: "~> 1.0",
-      description: description,
-      package: package,
+      description: description(),
+      package: package(),
     ]
   end
 


### PR DESCRIPTION
Current implementation of mix eunit command uses {:application, Mix.Project.config[:app]} primitive. This primitive runs all unit tests for modules of given application. If one does TDD and has test modules that don't correspond to any application module yet, these test modules won't be executed.

The pull request just puts test_beams folder path as an argument to :eunit.test command, so all test modules that exist are ran.

Additional modification is just removing compilation warnings.